### PR TITLE
adds options adapter

### DIFF
--- a/lib/zip/zip.rb
+++ b/lib/zip/zip.rb
@@ -9,3 +9,15 @@ Zip::ZipInputStream          =  Zip::InputStream
 Zip::ZipOutputStream         =  Zip::OutputStream
 Zip::ZipStreamableDirectory  =  Zip::StreamableDirectory
 Zip::ZipStreamableStream     =  Zip::StreamableStream
+
+module Zip
+  class OptionsAdapter
+    def []=(key, value)
+      Zip.send("#{key}=", value)
+    end
+  end
+
+  def self.options
+    @adapter = OptionsAdapter.new
+  end
+end

--- a/test/zip_test.rb
+++ b/test/zip_test.rb
@@ -1,0 +1,11 @@
+require 'minitest/autorun'
+require 'zip'
+require_relative '../lib/zip/zip'
+
+describe Zip, '#options[]' do
+  it 'translates the 0.9 Zip.options[<name>] interface to the new Zip.<name> interface' do
+    Zip.options[:continue_on_exists_proc] = '123'
+
+    Zip.continue_on_exists_proc.must_equal('123')
+  end
+end


### PR DESCRIPTION
with this patch you can now set options the old way, too (`Zip.options[:foo] = :bar`).
